### PR TITLE
Feature: Login page - unhappy path

### DIFF
--- a/tests/pages/base.ts
+++ b/tests/pages/base.ts
@@ -22,4 +22,8 @@ export class Base {
 	async press(locator: Locator) {
 		await locator.click();
 	}
+
+	async elementIsPresentOnDom(locator: Locator) {
+		await locator.isVisible();
+	}
 }

--- a/tests/pages/login-page.ts
+++ b/tests/pages/login-page.ts
@@ -11,6 +11,9 @@ export class LoginPage extends Common {
 	private readonly _twitterButton: Locator;
 	private readonly _facebookButton: Locator;
 	private readonly _youTubeButton: Locator;
+	private readonly _genericValidationElement: Locator;
+	private readonly _usernameValidationElement: Locator;
+	private readonly _passwordValidationElement: Locator;
 
 	constructor(page: Page) {
 		super(page);
@@ -22,6 +25,9 @@ export class LoginPage extends Common {
 		this._facebookButton = page.getByRole('link').nth(1);
 		this._twitterButton = page.getByRole('link').nth(2);
 		this._youTubeButton = page.getByRole('link').nth(3);
+		this._genericValidationElement = page.getByText('Required');
+		this._usernameValidationElement = page.getByText('Required').first();
+		this._passwordValidationElement = page.getByText('Required').nth(1);
 	}
 
 	async navigateToLoginPage(loginPageUrl: string) {
@@ -58,5 +64,17 @@ export class LoginPage extends Common {
 
 	async pressYouTubeButton() {
 		await this.press(this._youTubeButton);
+	}
+
+	async genericValidationElementIsPresent() {
+		await this.elementIsPresentOnDom(this._genericValidationElement);
+	}
+
+	async usernameValidationElementIsPresent() {
+		await this.elementIsPresentOnDom(this._usernameValidationElement);
+	}
+
+	async passwordValidationElementIsPresent() {
+		await this.elementIsPresentOnDom(this._passwordValidationElement);
 	}
 }

--- a/tests/pages/login-page/generic.spec.ts
+++ b/tests/pages/login-page/generic.spec.ts
@@ -1,0 +1,89 @@
+import { expect } from '@playwright/test';
+import { test } from '../../fixtures/login-page-fixture';
+
+test(
+	'A user attempts to interact with the OrangeHRM.Inc link on the login page',
+	{ tag: ['@generic-user', '@login-page'] },
+	async ({ base, common, page }) => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+
+		const [homePage] = await Promise.all([
+			page.waitForEvent('popup'),
+			common.pressOrangeIrmLink(),
+		]);
+
+		await homePage.waitForLoadState();
+
+		await expect(homePage).toHaveURL('https://www.orangehrm.com/');
+		await homePage.close();
+		await page.close();
+	},
+);
+
+test(
+	'A user attempts to use the LinkedIn link on the login page',
+	{ tag: ['@generic-user', '@login-page'] },
+	async ({ base, loginPage, page }) => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		const linkedInPage = page.waitForEvent('popup');
+		await loginPage.pressLinkedInButton();
+		const linkedIn = await linkedInPage;
+
+		await expect(linkedIn).toHaveURL('https://www.linkedin.com/company/orangehrm');
+		await linkedIn.close();
+		await page.close();
+	},
+);
+
+test(
+	'A user attempts to use the Twitter/X link on the login page',
+	{ tag: ['@generic-user', '@login-page'] },
+	async ({ base, loginPage, page }) => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		const twitterPage = page.waitForEvent('popup');
+		await loginPage.pressTwitterButton();
+		const twitter = await twitterPage;
+
+		await expect(twitter).toHaveURL('https://x.com/orangehrm?lang=en');
+		await twitter.close();
+		await page.close();
+	},
+);
+
+test(
+	'A user attempts to use the Facebook link on the login page',
+	{ tag: ['@generic-user', '@login-page'] },
+	async ({ base, loginPage, page }) => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		const facebookPage = page.waitForEvent('popup');
+		await loginPage.pressFacebookButton();
+		const facebook = await facebookPage;
+
+		await expect(facebook).toHaveURL('https://www.facebook.com/OrangeHRM/');
+		await facebook.close();
+		await page.close();
+	},
+);
+
+test(
+	'A user attempts to use the YouTube link on the login page',
+	{ tag: ['@generic-user', '@login-page'] },
+	async ({ base, loginPage, page }) => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		const youTubePage = page.waitForEvent('popup');
+		await loginPage.pressYouTubeButton();
+		const youTube = await youTubePage;
+
+		const orangeHome = youTube.getByTitle('(1) OrangeHRM Inc - YouTube', {
+			exact: true,
+		});
+		const consentPage = youTube.getByTitle('Before you continue to YouTube', {
+			exact: true,
+		});
+
+		expect(orangeHome.or(consentPage)).toBeDefined();
+
+		await youTube.close();
+		await page.close();
+	},
+);

--- a/tests/pages/login-page/happy.spec.ts
+++ b/tests/pages/login-page/happy.spec.ts
@@ -2,25 +2,6 @@ import { expect } from '@playwright/test';
 import { test } from '../../fixtures/login-page-fixture';
 
 test(
-	'A user attempts to interact with the OrangeHRM.Inc link on the login page',
-	{ tag: ['@generic-user', '@login-page'] },
-	async ({ base, common, page }) => {
-		await base.navigateToUrl('/web/index.php/auth/login');
-
-		const [homePage] = await Promise.all([
-			page.waitForEvent('popup'),
-			common.pressOrangeIrmLink(),
-		]);
-
-		await homePage.waitForLoadState();
-
-		await expect(homePage).toHaveURL('https://www.orangehrm.com/');
-		await homePage.close();
-		await page.close();
-	},
-);
-
-test(
 	'A previously registered user successfully logs in to the Orange HRM service',
 	{ tag: ['@happy-path', '@login-page'] },
 	async ({ base, loginPage, page }) => {
@@ -31,74 +12,6 @@ test(
 
 		await expect(page).toHaveURL('/web/index.php/dashboard/index');
 
-		await page.close();
-	},
-);
-
-test(
-	'A user attempts to use the LinkedIn link on the login page',
-	{ tag: ['@generic-user', '@login-page'] },
-	async ({ base, loginPage, page }) => {
-		await base.navigateToUrl('/web/index.php/auth/login');
-		const linkedInPage = page.waitForEvent('popup');
-		await loginPage.pressLinkedInButton();
-		const linkedIn = await linkedInPage;
-
-		await expect(linkedIn).toHaveURL('https://www.linkedin.com/company/orangehrm');
-		await linkedIn.close();
-		await page.close();
-	},
-);
-
-test(
-	'A user attempts to use the Twitter/X link on the login page',
-	{ tag: ['@generic-user', '@login-page'] },
-	async ({ base, loginPage, page }) => {
-		await base.navigateToUrl('/web/index.php/auth/login');
-		const twitterPage = page.waitForEvent('popup');
-		await loginPage.pressTwitterButton();
-		const twitter = await twitterPage;
-
-		await expect(twitter).toHaveURL('https://x.com/orangehrm?lang=en');
-		await twitter.close();
-		await page.close();
-	},
-);
-
-test(
-	'A user attempts to use the Facebook link on the login page',
-	{ tag: ['@generic-user', '@login-page'] },
-	async ({ base, loginPage, page }) => {
-		await base.navigateToUrl('/web/index.php/auth/login');
-		const facebookPage = page.waitForEvent('popup');
-		await loginPage.pressFacebookButton();
-		const facebook = await facebookPage;
-
-		await expect(facebook).toHaveURL('https://www.facebook.com/OrangeHRM/');
-		await facebook.close();
-		await page.close();
-	},
-);
-
-test(
-	'A user attempts to use the YouTube link on the login page',
-	{ tag: ['@generic-user', '@login-page'] },
-	async ({ base, loginPage, page }) => {
-		await base.navigateToUrl('/web/index.php/auth/login');
-		const youTubePage = page.waitForEvent('popup');
-		await loginPage.pressYouTubeButton();
-		const youTube = await youTubePage;
-
-		const orangeHome = youTube.getByTitle('(1) OrangeHRM Inc - YouTube', {
-			exact: true,
-		});
-		const consentPage = youTube.getByTitle('Before you continue to YouTube', {
-			exact: true,
-		});
-
-		expect(orangeHome.or(consentPage)).toBeDefined();
-
-		await youTube.close();
 		await page.close();
 	},
 );

--- a/tests/pages/login-page/happy.spec.ts
+++ b/tests/pages/login-page/happy.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from './fixtures/login-page-fixture';
+import { test } from '../../fixtures/login-page-fixture';
 
 test(
 	'A user attempts to interact with the OrangeHRM.Inc link on the login page',

--- a/tests/pages/login-page/unhappy.spec.ts
+++ b/tests/pages/login-page/unhappy.spec.ts
@@ -1,0 +1,70 @@
+import { test } from '../../fixtures/login-page-fixture';
+
+test.describe(
+	'Invalid user attempts to login - variations',
+	{
+		tag: ['@login-page', '@unhappy'],
+		annotation: { type: 'Feature', description: 'Feat(OHRM-007): Login page - unhappy path' },
+	},
+	() => {
+		test(
+			'An invalid user attempts to login with an unknown password only',
+			{
+				annotation: {
+					type: 'Acceptance Criteria',
+					description:
+						'AC1: The one where an invalid user attempts to login with an unknown password only',
+				},
+			},
+			async ({ page }) => {},
+		);
+
+		test(
+			'An invalid user attempts to login with an unknown username only',
+			{
+				annotation: {
+					type: 'Acceptance Criteria',
+					description:
+						'AC2: The one where an invalid user attempts to login with an unknown username only',
+				},
+			},
+			async ({ page }) => {},
+		);
+
+		test(
+			'An invalid user attempts to login with an unknown username and unknown password',
+			{
+				annotation: {
+					type: 'Acceptance Criteria',
+					description:
+						'AC3: The one where an invalid user attempts to login with an unknown username and password',
+				},
+			},
+			async ({ page }) => {},
+		);
+
+		test(
+			'An invalid user attempts to login with a known username and an unknown password',
+			{
+				annotation: {
+					type: 'Acceptance Criteria',
+					description:
+						'AC4: The one where an Invalid user attempts to login with a known username with an unknown password',
+				},
+			},
+			async ({ page }) => {},
+		);
+
+		test(
+			'An invalid user attempts to login with an unknown username and a known password',
+			{
+				annotation: {
+					type: 'Acceptance Criteria',
+					description:
+						'AC5: The one where an invalid user attempts to use a known password with an unknown username',
+				},
+			},
+			async ({ page }) => {},
+		);
+	},
+);

--- a/tests/pages/login-page/unhappy.spec.ts
+++ b/tests/pages/login-page/unhappy.spec.ts
@@ -1,70 +1,123 @@
+import { expect } from '@playwright/test';
 import { test } from '../../fixtures/login-page-fixture';
 
-test.describe(
-	'Invalid user attempts to login - variations',
+const knownUser = 'Admin';
+const knownPassword = 'admin123';
+const unknownUser = 'IAMGOD';
+const unknownPassword = 'LetMeInPlease123';
+const emptyInput = '';
+
+test(
+	'An invalid user attempts to login with an unknown password only',
 	{
-		tag: ['@login-page', '@unhappy'],
-		annotation: { type: 'Feature', description: 'Feat(OHRM-007): Login page - unhappy path' },
+		annotation: {
+			type: 'Acceptance Criteria',
+			description:
+				'AC1: The one where an invalid user attempts to login with an unknown password only',
+		},
 	},
-	() => {
-		test(
-			'An invalid user attempts to login with an unknown password only',
-			{
-				annotation: {
-					type: 'Acceptance Criteria',
-					description:
-						'AC1: The one where an invalid user attempts to login with an unknown password only',
-				},
-			},
-			async ({ page }) => {},
-		);
+	async ({ base, loginPage, page }): Promise<void> => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		await loginPage.fillUserName(emptyInput);
+		await loginPage.fillPassword(unknownPassword);
+		await loginPage.pressLoginButton();
 
-		test(
-			'An invalid user attempts to login with an unknown username only',
-			{
-				annotation: {
-					type: 'Acceptance Criteria',
-					description:
-						'AC2: The one where an invalid user attempts to login with an unknown username only',
-				},
-			},
-			async ({ page }) => {},
-		);
+		await expect(page.getByText('Required')).toBeVisible();
+	},
+);
 
-		test(
-			'An invalid user attempts to login with an unknown username and unknown password',
-			{
-				annotation: {
-					type: 'Acceptance Criteria',
-					description:
-						'AC3: The one where an invalid user attempts to login with an unknown username and password',
-				},
-			},
-			async ({ page }) => {},
-		);
+test(
+	'An invalid user attempts to login with an unknown username only',
+	{
+		annotation: {
+			type: 'Acceptance Criteria',
+			description:
+				'AC2: The one where an invalid user attempts to login with an unknown username only',
+		},
+	},
+	async ({ base, loginPage, page }): Promise<void> => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		await loginPage.fillUserName(unknownUser);
+		await loginPage.fillPassword(emptyInput);
+		await loginPage.pressLoginButton();
 
-		test(
-			'An invalid user attempts to login with a known username and an unknown password',
-			{
-				annotation: {
-					type: 'Acceptance Criteria',
-					description:
-						'AC4: The one where an Invalid user attempts to login with a known username with an unknown password',
-				},
-			},
-			async ({ page }) => {},
-		);
+		await expect(page.getByText('Required')).toBeVisible();
+	},
+);
 
-		test(
-			'An invalid user attempts to login with an unknown username and a known password',
-			{
-				annotation: {
-					type: 'Acceptance Criteria',
-					description:
-						'AC5: The one where an invalid user attempts to use a known password with an unknown username',
-				},
-			},
-			async ({ page }) => {},
-		);
+test(
+	'An invalid user attempts to login with an unknown username and unknown password',
+	{
+		annotation: {
+			type: 'Acceptance Criteria',
+			description:
+				'AC3: The one where an invalid user attempts to login with an unknown username and unknown password',
+		},
+	},
+	async ({ base, loginPage, page }): Promise<void> => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		await loginPage.fillUserName(unknownUser);
+		await loginPage.fillPassword(unknownPassword);
+		await loginPage.pressLoginButton();
+
+		await expect(page.getByText('Invalid credentials')).toBeVisible();
+	},
+);
+
+test(
+	'An invalid user attempts to login with a known username and an unknown password',
+	{
+		annotation: {
+			type: 'Acceptance Criteria',
+			description:
+				'AC4: The one where an Invalid user attempts to login with a known username with an unknown password',
+		},
+	},
+	async ({ base, loginPage, page }): Promise<void> => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		await loginPage.fillUserName(knownUser);
+		await loginPage.fillPassword(unknownPassword);
+		await loginPage.pressLoginButton();
+
+		await expect(page.getByText('Invalid credentials')).toBeVisible();
+	},
+);
+
+test(
+	'An invalid user attempts to login with an unknown username and a known password',
+	{
+		annotation: {
+			type: 'Acceptance Criteria',
+			description:
+				'AC5: The one where an invalid user attempts to use a known password with an unknown username',
+		},
+	},
+	async ({ base, loginPage, page }): Promise<void> => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		await loginPage.fillUserName(unknownUser);
+		await loginPage.fillPassword(knownPassword);
+		await loginPage.pressLoginButton();
+
+		await expect(page.getByText('Invalid credentials')).toBeVisible();
+	},
+);
+
+test(
+	'An invalid user attempts to login by inputting nothing into either the username or password input fields',
+	{
+		annotation: {
+			type: 'Acceptance Criteria',
+			description:
+				'AC6: The one where a user attempts to login by inputting nothing into either password or username fields',
+		},
+	},
+	async ({ base, loginPage, page }): Promise<void> => {
+		await base.navigateToUrl('/web/index.php/auth/login');
+		await loginPage.fillUserName(emptyInput);
+		await loginPage.fillPassword(emptyInput);
+		await loginPage.pressLoginButton();
+
+		await expect(page.getByText('Required').first()).toBeVisible();
+		await expect(page.getByText('Required').nth(1)).toBeVisible();
 	},
 );

--- a/tests/pages/password-reset-page/generic.spec.ts
+++ b/tests/pages/password-reset-page/generic.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from '@playwright/test';
-import { test } from './fixtures/password-reset-page-fixture';
+import { test } from '../../fixtures/password-reset-page-fixture';
 
 test(
 	'A user attempts to request a password reset',


### PR DESCRIPTION
- Resolves [Feat(OHRM-007)](https://trello.com/c/sGz74guo/13-featohrm-007-login-page-unhappy-path)
- Separated individual paths (happy/unhappy/generic) into individual files for existing test cases
- Renamed `password-reset-page.ts` to 'generic.spec.ts' as it did not follow specified naming convention as above, nor did it conform to the given file extension pattern
- Added annotations and tags to all test cases on `/pages/login-page/unhappy.spec.ts`, this will be the standard moving forward, creating a tangible link between requirements and code
- Added return type of `Promise<void>` to each test case on `/pages/login-page/unhappy.spec.ts`, we are using TypeScript after all. This will be the standard moving forward
-  Modified:   `tests/pages/base.ts`
- Modified:   `tests/pages/login-page.ts`
- Modified:   `tests/pages/login-page/happy.spec.ts`
- Modified:   `tests/pages/login-page/unhappy.spec.ts`
