### PR TITLE
Feature: User inputs empty string into forgotten password username field

### DIFF
--- a/tests/pages/password-reset-page/generic.spec.ts
+++ b/tests/pages/password-reset-page/generic.spec.ts
@@ -32,3 +32,31 @@ test(
 		await expect(page).toHaveURL('/web/index.php/auth/login');
 	},
 );
+
+test.describe(
+	'Feat(OHRM-022): User inputs empty string when requesting password reset',
+	{ tag: ['@generic-user', '@password-reset-page'] },
+	() => {
+		test(
+			'An invalid user attempts to login with an unknown password only',
+			{
+				annotation: {
+					type: 'Acceptance Criteria',
+					description:
+						'AC1: The one where a user attempts to request a password reset with an empty string',
+				},
+			},
+			async ({ base, loginPage, page, passwordResetPage }) => {
+				await base.navigateToUrl('/web/index.php/auth/login');
+
+				await loginPage.pressForgotPasswordButton(),
+					expect(page).toHaveURL('/web/index.php/auth/requestPasswordResetCode');
+
+				await passwordResetPage.fillUserNameWithEmptyString();
+				await passwordResetPage.pressCancelButton();
+
+				await expect(page).toHaveURL('/web/index.php/auth/login');
+			},
+		);
+	},
+);


### PR DESCRIPTION
### Feature:  User inputs empty string when requesting password reset

- Resolves [Feat(OHRM-022)](https://trello.com/c/DbTvGZ3n/42-featohrm-022-user-inputs-empty-string-when-requesting-password-reset)
-  Modified:   `tests/pages/password-reset-page/generic.spec.ts`

This was a missed test case in regards to the generic functionality regarding the password reset page as per [Feat(OHRM-008)](https://trello.com/c/AhPul21y/14-featohrm-008-password-reset-page-happy-path)